### PR TITLE
Fixed "calculator.ico" file not found

### DIFF
--- a/Calculator/main.py
+++ b/Calculator/main.py
@@ -1,10 +1,14 @@
 import customtkinter as ctk
+import os
 
 class Calculator(ctk.CTk):
     def __init__(self):
         super().__init__()
         self.geometry("400x600")
-        self.iconbitmap("calculator.ico")
+        if os.path.exists("calculator.ico"):
+            self.iconbitmap('calculator.ico')
+        else:
+            self.iconbitmap("Calculator/calculator.ico")
         self.resizable(False, False)
         self.title("Calculator")
         ctk.set_appearance_mode("dark")


### PR DESCRIPTION
A quick fix to make the program search for the calculator.ico file in the folder where the code is being ran, and if it's not there, use the one on "Calculator/calculator.ico". It uses the path.exists() method to search for the icon file. Imports the "os" library, which is already installed with python.